### PR TITLE
Fixed a dumpSTR test that was failing because it assumed the user had…

### DIFF
--- a/dumpSTR/dumpSTR.py
+++ b/dumpSTR/dumpSTR.py
@@ -54,7 +54,8 @@ def MakeWriter(outfile, invcf, command):
     invcf.metadata["command-DumpSTR"] = [command]
     try:
         writer = vcf.Writer(open(outfile, "w"), invcf)
-    except OSError:
+    except OSError as e:
+        common.WARNING(str(e))
         writer = None
     return writer
 

--- a/tests/test_dumpSTR/test_dumpSTR.py
+++ b/tests/test_dumpSTR/test_dumpSTR.py
@@ -393,14 +393,23 @@ def test_InvalidGenotyperOptions():
     assert main(args)==1
     args.eh_min_call_LC = None
 
-def test_InvalidOutput():
+def test_InvalidOutput(capsys):
     args = base_argparse()
     fname = os.path.join(VCFDIR, "test_popstr.vcf")
     args.vcf = fname
-    args.out = "/notadirectory"
-    assert main(args)==1
-    args.out = os.path.join(DUMPDIR, "dummydir","test")
-    assert main(args)==1
+
+    # Fail when trying to output inside a nonexistant directory
+    args.out = os.path.join(DUMPDIR, "notadirectory","somefilename")
+    assert main(args) == 1
+
+    # To simulate a permissions issue: fail when trying to write a file in a location
+    # that is already a directory
+    capsys.readouterr()
+    os.makedirs(os.path.join(DUMPDIR, "foo.vcf"), exist_ok=True)
+    args.out = os.path.join(DUMPDIR, "foo")
+    assert main(args) == 1
+    # Make sure we produce a meaningful error message for this issue
+    assert 'Is a directory:' in str(capsys.readouterr())
 
 def test_TwoDumpSTRRounds():
     args = base_argparse()


### PR DESCRIPTION
… no permissions to write files to the root directory '/', but that's not true in some dockered environments