### PR TITLE
shortened error message for statSTR no stat selected

### DIFF
--- a/trtools/statSTR/statSTR.py
+++ b/trtools/statSTR/statSTR.py
@@ -315,8 +315,7 @@ def getargs(): # pragma: no cover
             stat_dict = {a.dest:getattr(args,a.dest,None) for a in grp._group_actions}
 
     if not any(stat_dict.values()):
-        common.WARNING("Error: Please use at least one of the flags in the Stats group")
-        parser.print_help(sys.stderr)
+        common.WARNING("Error: Please use at least one of the flags in the Stats group. See statSTR --help for options.")
         return None
     return args
 


### PR DESCRIPTION
When no statistic is selected, the message "Error: Please use at least one of the flags in the Stats group" gets buried by the help message. I instead pointed users to `statSTR --help` to see all options.