### PR TITLE
clarifying mergeSTR docs

### DIFF
--- a/trtools/mergeSTR/README.rst
+++ b/trtools/mergeSTR/README.rst
@@ -1,5 +1,5 @@
 .. overview_directive
-.. |mergeSTR overview| replace:: MergeSTR merges VCF files from differing TR genotyping tools into a single VCF file.
+.. |mergeSTR overview| replace:: MergeSTR merges multiple VCF files containing TR genotypes into a single VCF file.
 .. overview_directive_done
 
 MergeSTR 
@@ -13,7 +13,7 @@ While other VCF libraries have capabilities to merge VCF files, they do not alwa
 
 Usage 
 -----
-MergeSTR takes as input two or more VCF files with TR genotypes and outputs a combined VCF file. Note, input VCF files must be sorted, indexed, and have the appropriate `##contig` header lines.
+MergeSTR takes as input two or more VCF files with TR genotypes and outputs a combined VCF file. Note, input VCF files must be bgzipped, sorted, indexed, and have the appropriate `##contig` header lines. See "Instructions on Compressing and Indexing VCF files" below for commands for preparing tabix-indexed VCF files.
 
 To run mergeSTR use the following command::
 
@@ -88,8 +88,8 @@ In addition to proper merging of alleles at multi-allelic sites, MergeSTR suppor
 * Supported INFO fields: END, RU, RC
 * Supported FORMAT fields: DP, SR, FL, ML
 
-Instruction on Compressing and Indexing VCF files
--------------------------------------------------
+Instructions on Compressing and Indexing VCF files
+--------------------------------------------------
 MergeSTR requires the input file to be compressed and indexed. Use the following commands to create compressed and indexed vcf file::
   
   bgzip file.vcf

--- a/trtools/mergeSTR/README.rst
+++ b/trtools/mergeSTR/README.rst
@@ -9,7 +9,7 @@ MergeSTR
 
 If TR genotyping was performed separately on different samples or batches of samples, mergeSTR can be used to combine the resulting VCFs into one file. This is often necessary for downstream steps such as: computing per-locus statistics, performing per-locus filtering, and association testing.
 
-While other VCF libraries have capabilities to merge VCF files, they do not always handle multi-allelic STRs properly, especially if the allele definitions are different across files. MergeSTR is TR-aware and currently handles VCF files obtained by: GangSTR, HipSTR, ExpansionHunter, popSTR, or adVNTR. See below for specific VCF fields supported for each genotyper.
+While other VCF libraries have capabilities to merge VCF files, they do not always handle multi-allelic STRs properly, especially if different alternate alleles are present in different files. MergeSTR is TR-aware and currently handles VCF files obtained by: GangSTR, HipSTR, ExpansionHunter, popSTR, or adVNTR. See below for specific VCF fields supported for each genotyper.
 
 Usage 
 -----

--- a/trtools/mergeSTR/README.rst
+++ b/trtools/mergeSTR/README.rst
@@ -66,6 +66,16 @@ Supported VCF fields
 
 In addition to proper merging of alleles at multi-allelic sites, MergeSTR supports the following VCF fields for each tool. Fields not listed are currently ignored when merging. INFO fields below are expected to be constant across loci being merged.
 
+**AdVNTR**
+
+* Supported INFO fields: END, RU, RC
+* Supported FORMAT fields: DP, SR, FL, ML
+
+**ExpansionHunter**
+
+* Supported INFO fields: END, REF, REPID, RL, RU, SVTYPE
+* Supported FORMAT fields: ADFL,ADIR,ADSP,LC,REPCI,REPCN,SO
+
 **GangSTR**
 
 * Supported INFO fields: END, RU, PERIOD, REF, EXPTHRESH
@@ -76,20 +86,10 @@ In addition to proper merging of alleles at multi-allelic sites, MergeSTR suppor
 * Supported INFO fields: START, END, PERIOD
 * Supported FORMAT fields: GB,Q,PQ,DP,DSNP,PSNP,PDP,GLDIFF,DSTUTTER,DFLANKINDEL,AB,FS,DAB,ALLREADS,MALLREADS
 
-**ExpansionHunter**
-
-* Supported INFO fields: END, REF, REPID, RL, RU, SVTYPE
-* Supported FORMAT fields: ADFL,ADIR,ADSP,LC,REPCI,REPCN,SO
-
 **PopSTR**
 
 * Supported INFO fields: Motif
 * Supported FORMAT fields: AD, DP, PL
-
-**AdVNTR**
-
-* Supported INFO fields: END, RU, RC
-* Supported FORMAT fields: DP, SR, FL, ML
 
 Instructions on Compressing and Indexing VCF files
 --------------------------------------------------

--- a/trtools/mergeSTR/README.rst
+++ b/trtools/mergeSTR/README.rst
@@ -2,7 +2,7 @@
 .. |mergeSTR overview| replace:: MergeSTR merges multiple VCF files produced by the same TR genotyper into a single VCF file.
 .. overview_directive_done
 
-MergeSTR 
+MergeSTR
 ========
 
 |mergeSTR overview|
@@ -11,33 +11,34 @@ If TR genotyping was performed separately on different samples or batches of sam
 
 While other VCF libraries have capabilities to merge VCF files, they do not always handle multi-allelic STRs properly, especially if different alternate alleles are present in different files. MergeSTR is TR-aware.
 
-Note: mergeSTR currently does not support merging VCFs produced by different TR genotypers.
+Note: mergeSTR does not support merging VCFs produced by different TR genotypers as the desired outcome of such an operation is highly dependant on the use-case at hand.
+If this is your use case and you with it to be supported, consider `filing an issue <https://github.com/gymreklab/TRTools/issues>`_ with us.
 
-Usage 
+Usage
 -----
-MergeSTR takes as input two or more VCF files with TR genotypes and outputs a combined VCF file. Note, input VCF files must be bgzipped, sorted, indexed, and have the appropriate `##contig` header lines. See "Instructions on Compressing and Indexing VCF files" below for commands for preparing tabix-indexed VCF files.
+MergeSTR takes as input two or more VCF files with TR genotypes and outputs a combined VCF file. Note, input VCF files must be bgzipped, sorted, indexed, and have the appropriate :code:`##contig` header lines. See `Instructions on Compressing and Indexing VCF files`_ below for commands for preparing tabix-indexed VCF files.
 
 To run mergeSTR use the following command::
 
 	mergeSTR \
-  	  --vcfs <vcf file1, vcf file2, ...> \
+  	  --vcfs <file1.vcf,file2.vcf,...> \
   	  --out test \
   	  [additional options]
 
-Required Parameters: 
+Required Parameters:
 
-* :code:`--vcf <VCF>`: Comma-separated list of VCF files to merge. All must have been created by the same TR genotyper. Must be bgzipped, sorted, and indexed. 
+* :code:`--vcf <VCF>`: Comma-separated list of VCF files to merge. All must have been created by the same TR genotyper. Must be bgzipped, sorted, and indexed.
 * :code:`--vcftype <string>`: Type of VCF files being merged. Default = :code:`auto`. Must be one of: :code:`gangstr`, :code:`advntr`, :code:`hipstr`, :code:`eh`, :code:`popstr`.
 * :code:`--out <string>`: prefix to name output files
 
-Special Merge Options: 
+Special Merge Options:
 
 * :code:`--update-sample-from-file`: Append file names to sample names. Useful if sample names are repeated across VCF files.
 
-Optional Additional Parameters: 
+Optional Additional Parameters:
 
-* :code:`--verbose`: Prints out extra information 
-* :code:`--quiet`: Doesn't print out anything 
+* :code:`--verbose`: Prints out extra information
+* :code:`--quiet`: Doesn't print out anything
 
 Example MergeSTR command
 ------------------------
@@ -77,7 +78,7 @@ In addition to proper merging of alleles at multi-allelic sites, MergeSTR suppor
 
 **ExpansionHunter**
 
-* Supported INFO fields: END, REF, REPID, RL, RU, SVTYPE 
+* Supported INFO fields: END, REF, REPID, RL, RU, SVTYPE
 * Supported FORMAT fields: ADFL,ADIR,ADSP,LC,REPCI,REPCN,SO
 
 **PopSTR**
@@ -93,7 +94,7 @@ In addition to proper merging of alleles at multi-allelic sites, MergeSTR suppor
 Instructions on Compressing and Indexing VCF files
 --------------------------------------------------
 MergeSTR requires the input file to be compressed and indexed. Use the following commands to create compressed and indexed vcf file::
-  
+
   bgzip file.vcf
   tabix -p vcf file.vcf.gz
 

--- a/trtools/mergeSTR/mergeSTR.py
+++ b/trtools/mergeSTR/mergeSTR.py
@@ -3,11 +3,11 @@
 Tool for merging STR VCF files from GangSTR
 """
 
-# Load external libraries
 import argparse
-import os
-import numpy as np
 import sys
+from typing import List
+
+import numpy as np
 import vcf
 
 import trtools.utils.common as common
@@ -291,7 +291,7 @@ def GetGT(gt_alleles, alleles):
     newgt = [alleles.index(gta.upper()) for gta in gt_alleles]
     return "/".join([str(item) for item in newgt])
 
-def GetSampleInfo(record, alleles, formats, args):
+def GetSampleInfo(record, alleles, formats) -> List[str]:
     r"""Output sample FORMAT info
 
     Parameters
@@ -302,13 +302,12 @@ def GetSampleInfo(record, alleles, formats, args):
        List of REF + ALT alleles
     formats : list of str
        List of VCF FORMAT items
-    args : argparse namespace
-       User options
 
     Returns
     -------
-    sampleinfo : str
-       FORMAT fields for the sample
+    record_items : List[str]
+        A list of the string representations of the GT and other format
+        fields, one such string for each sample in the record
     """
     assert "GT" not in formats # since we will add that
     record_items = []
@@ -322,7 +321,7 @@ def GetSampleInfo(record, alleles, formats, args):
         # Add rest of formats
         for fmt in formats:
             val = sample[fmt]
-            if type(val)==list: val = ",".join([str(item) for item in val])
+            if isinstance(val, list): val = ",".join([str(item) for item in val])
             sample_items.append(val)
         record_items.append(":".join([str(item) for item in sample_items]))
     return record_items
@@ -379,7 +378,7 @@ def MergeRecords(readers, current_records, mergelist, vcfw, args, useinfo, usefo
     alleles = [ref_allele]+alt_alleles
     for i in range(len(mergelist)):
         if mergelist[i]:
-            output_items.extend(GetSampleInfo(current_records[i], alleles, useformat, args))
+            output_items.extend(GetSampleInfo(current_records[i], alleles, useformat))
         else:
             output_items.extend([NOCALLSTRING]*len(readers[i].samples)) # NOCALL
     vcfw.write("\t".join(output_items)+"\n")

--- a/trtools/mergeSTR/mergeSTR.py
+++ b/trtools/mergeSTR/mergeSTR.py
@@ -32,7 +32,7 @@ INFOFIELDS = {
                ("NFILT", False), ("DP", False), ("DSNP", False), ("DSTUTTER", False), \
                ("DFLANKINDEL", False)],
     "eh": [("END", True), ("REF", True), ("REPID", True), ("RL", True), \
-           ("RU", True), ("SVTYPE", False), ("VARID", False)],
+           ("RU", True), ("SVTYPE", True), ("VARID", False)],
     "popstr": [("Motif", True)], # TODO ("RefLen", True) omitted. since it is marked as "A" incorrectly
     "advntr": [("END", True), ("VID", False), ("RU", True), ("RC", True)]
 }

--- a/trtools/mergeSTR/tests/test_mergeSTR.py
+++ b/trtools/mergeSTR/tests/test_mergeSTR.py
@@ -214,3 +214,6 @@ def test_GetSampleInfo(args, vcfdir):
 # Why don't we fail if info fields are different? That's what required is
 # supposed to mean. Or at least, don't emit that record!!!
 # TODO we should intelligently merge info fields with reqd = false
+# TODO there is not a single test here that confirms that the output VCF
+# actually is a VCF, has the proper headers and each record has the proper
+# format fields and info fields and all that stuff. Write some meaningful tests.

--- a/trtools/mergeSTR/tests/test_mergeSTR.py
+++ b/trtools/mergeSTR/tests/test_mergeSTR.py
@@ -224,3 +224,5 @@ def test_GetSampleInfo(args, vcfdir):
 # we encounter a format field that we didn't expect, we ignore it. Why? Why
 # not just use the appropriate format fields for the appropriate samples
 # in each merged record?
+# TODO what if there are multiple records at the same location in the same VCF
+# we should fail right? Confirm this.

--- a/trtools/mergeSTR/tests/test_mergeSTR.py
+++ b/trtools/mergeSTR/tests/test_mergeSTR.py
@@ -217,3 +217,10 @@ def test_GetSampleInfo(args, vcfdir):
 # TODO there is not a single test here that confirms that the output VCF
 # actually is a VCF, has the proper headers and each record has the proper
 # format fields and info fields and all that stuff. Write some meaningful tests.
+# TODO confirm we actually support the fields we say we support (like, they're
+# presenting in the output files when we run on the appropriate test files)
+# TODO why do we even bother saying which format fields we support? We just
+# append them all anyway. The only difference as far as I can tell is that if
+# we encounter a format field that we didn't expect, we ignore it. Why? Why
+# not just use the appropriate format fields for the appropriate samples
+# in each merged record?


### PR DESCRIPTION
Clarifying misleading mergeSTR summary at the top of the page, which previously suggested mergeSTR should be used to merge VCFs from multiple TR genotypers. In fact, mergeSTR requires the VCFs being merged to be created by the same genotyper.