### PR TITLE
Trying to fix set is not ordered errors

### DIFF
--- a/trtools/qcSTR/qcSTR.py
+++ b/trtools/qcSTR/qcSTR.py
@@ -136,7 +136,7 @@ def OutputSampleCallrate(sample_calls, fname):
     fname : str
         Filename of output plot
     """
-    samples = sample_calls.keys()
+    samples = list(sample_calls.keys())
     data = pd.DataFrame({"sample": samples, "numcalls": [sample_calls[key] for key in samples]})
     #data = data.sort_values("numcalls") # Commented because the order would be incorrect if sorted
     fig = plt.figure()


### PR DESCRIPTION
Extract samples as a list instead of a set. This should force Pandas to respect the ordering we give it, even if it is arbitrary because it was generated by iterating over an unordered set