### PR TITLE
Cyvcf2 mac tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ jobs:
     - os: linux
       python: 3.6
     - os: osx
-      language: sh
-      addons:
-        homebrew:
-          packages:
-          - python3
-          - openssl
-          update: true
+      python: 3.5
+      # language: sh
+      # addons:
+      #   homebrew:
+      #     packages:
+      #     - python3
+      #     - openssl
+      #     update: true
       before_install:
         - pip3 install virtualenv
         - virtualenv -p python3 ~/venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ jobs:
       osx_image: xcode12
       language: generic
       env: PYTHON=36
-      # language: sh
-      # addons:
-      #   homebrew:
-      #     packages:
-      #     - python3
-      #     - openssl
-      #     update: true
       before_install:
         - pip3 install virtualenv
         - virtualenv -p python3 ~/venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ jobs:
     - os: linux
       python: 3.6
     - os: osx
-      python: 3.5
+      osx_image: xcode12
+      language: generic
+      env: PYTHON=36
       # language: sh
       # addons:
       #   homebrew:


### PR DESCRIPTION
Working on fixing Mac tests on travis.
The issue was that previously travis didn't natively support python3 tests on Mac. So we used to invoke a shell script and install everything from scratch using homebrew. This was the reason behind the timeout. 
Now there are more options for the mac environment and you can simply invoke a mac environment with python3 installed which solves the problem.