### PR TITLE
StatSTR sample subsetting

### DIFF
--- a/trtools/statSTR/statSTR.py
+++ b/trtools/statSTR/statSTR.py
@@ -493,6 +493,9 @@ def main(args):
             sample_list = np.array(
                 [item.strip() for item in open(sf, "r").readlines()]
             )
+            if not np.any(np.isin(all_samples, sample_list)):
+                common.WARNING("No samples from {} found in the VCF file".format(sf))
+                return 1
             sample_indexes.append(np.isin(all_samples, sample_list))
     else:
         sample_indexes = [None] # None is used to mean all samples

--- a/trtools/statSTR/statSTR.py
+++ b/trtools/statSTR/statSTR.py
@@ -487,7 +487,7 @@ def main(args):
         else:
             sample_prefixes = [str(item) for item in range(1, len(sfiles)+1)]
         if len(sfiles) != len(sample_prefixes):
-            common.MSG("--sample-prefixes must be same length as --samples")
+            common.WARNING("--sample-prefixes must be same length as --samples")
             return 1
         for sf in sfiles:
             sample_list = np.array(
@@ -516,7 +516,7 @@ def main(args):
     try:
         if args.out == "stdout":
             if args.plot_afreq:
-                common.MSG("Cannot use --out stdout when generating plots")
+                common.WARNING("Cannot use --out stdout when generating plots")
                 return 1
             outf = sys.stdout
         else:


### PR DESCRIPTION
Modified statSTR so:

* we fail gracefully if a user inputs a list of samples to `--samples` but none of those samples is present in the VCF. Previously this caused it to crash
* Changed `common.MSG` to `common.WARNING` otherwise error messages are not printed out unless in debug mode.