### PR TITLE
Fix a bug in qcSTR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ stats_gangstr.tab
 stats_popstr.tab
 test.tab
 test_association_results.tsv
+test_association_results.tsv.temp
+association_results.tsv
+association_results.tsv.temp

--- a/PUBLISHING.rst
+++ b/PUBLISHING.rst
@@ -118,7 +118,7 @@ You can tag a commit in two different ways.
 
 #. Command line:
 
-.. code-block: bash
+.. code-block:: bash
 
   git tag -a vX.Y.Z -m vX.Y.Z
   git push --tags

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,3 +1,10 @@
+5.0.1
+-----
+
+Bug fixes:
+
+* Remove outdated call in qcSTR to np.float()
+
 5.0.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LICENSE = 'MIT'
 curdir = os.path.abspath(os.path.dirname(__file__))
 MAJ = 5
 MIN = 0
-REV = 0
+REV = 1
 VERSION = '%d.%d.%d' % (MAJ, MIN, REV)
 with open(os.path.join(curdir, 'trtools/version.py'), 'w') as fout:
         fout.write(

--- a/test/cmdline_tests.sh
+++ b/test/cmdline_tests.sh
@@ -39,7 +39,7 @@ TMPDIR=$(mktemp -d -t tmp-XXXXXXXXXX)
 echo "Saving tmp files in ${TMPDIR}"
 
 # Check version
-for tool in mergeSTR dumpSTR qcSTR statSTR compareSTR
+for tool in mergeSTR dumpSTR qcSTR statSTR compareSTR associaTR
 do
     runcmd_pass "${tool} --version"
 done
@@ -72,6 +72,12 @@ runcmd_pass "compareSTR --vcf1 ${EXDATADIR}/NA12878_chr21_gangstr.sorted.vcf.gz 
 runcmd_fail "compareSTR --vcf1 ${EXDATADIR}/NA12878_chr21_gangstr.sorted.vcf.gz --vcf2 ${EXDATADIR}/NA12878_chr21_gangstr.sorted.vcf.gz --out ${TMPDIR}/kittens/xxx"
 runcmd_pass "compareSTR --vcf1 ${EXDATADIR}/NA12878_chr21_gangstr.sorted.vcf.gz --vcf2 ${EXDATADIR}/NA12878_chr21_gangstr.sorted.vcf.gz --out ${TMPDIR}"
 runcmd_fail "compareSTR --vcf1 ${EXDATADIR}/NA12878_chr21_gangstr.sorted.vcf.gz --vcf2 ${EXDATADIR}/NA12878_chr21_gangstr.sorted.vcf.gz --out ${TMPDIR}/"
+
+runcmd_pass "associaTR association_results.tsv ${EXDATADIR}/ceu_ex.vcf.gz simulated_phenotype ${EXDATADIR}/simulated_traits_0.npy --same-samples"
+runcmd_pass "associaTR association_results.tsv ${EXDATADIR}/ceu_ex.vcf.gz simulated_phenotype ${EXDATADIR}/simulated_traits_0.npy ${EXDATADIR}/simulated_traits_1.npy --same-samples"
+runcmd_fail "associaTR association_results.tsv nonexistant simulated_phenotype ${EXDATADIR}/simulated_traits_0.npy ${EXDATADIR}/simulated_traits_1.npy --same-samples"
+runcmd_fail "associaTR association_results.tsv ${EXDATADIR}/ceu_ex.vcf.gz simulated_phenotype nonexistant --same-samples"
+runcmd_fail "associaTR association_results.tsv ${EXDATADIR}/ceu_ex.vcf.gz simulated_phenotype ${EXDATADIR}/simulated_traits_0.npy nonexistant --same-samples"
 
 # check for invalid vcftypes
 

--- a/trtools/associaTR/associaTR.py
+++ b/trtools/associaTR/associaTR.py
@@ -17,7 +17,7 @@ import statsmodels.stats.weightstats
 from . import load_and_filter_genotypes
 import trtools
 import trtools.utils.utils as utils
-2
+
 pval_precision = 2
 
 def _merge_arrays(a, b):
@@ -576,7 +576,7 @@ def run():
         action='store_true',
         help=argparse.SUPPRESS
     )
-
+    parser.add_argument("--version", action="version", version = '{}'.format(trtools.__version__))
 
     args = parser.parse_args()
     main(args)

--- a/trtools/qcSTR/qcSTR.py
+++ b/trtools/qcSTR/qcSTR.py
@@ -197,8 +197,8 @@ def _BetterCDF(data: np.ndarray,
         ))
         ys = np.hstack((
             [1],
-            np.arange(n_points - 1, n_ones - 1, -1) / np.float(n_points),
-            [n_ones / np.float(n_points)]
+            np.arange(n_points - 1, n_ones - 1, -1) / n_points,
+            [n_ones / n_points]
         ))
     else:
         data = np.hstack((
@@ -208,7 +208,7 @@ def _BetterCDF(data: np.ndarray,
         ))
         ys = np.hstack((
             [1],
-            np.arange(n_points - 1, -1, -1) / np.float(n_points),
+            np.arange(n_points - 1, -1, -1) / n_points,
             [0]
         ))
     #ax.step(data, ys)#, where='post')

--- a/trtools/version.py
+++ b/trtools/version.py
@@ -1,4 +1,4 @@
 
 # THIS FILE IS GENERATED FROM SETUP.PY
-version = '5.0.0'
+version = '5.0.1'
 __version__ = version


### PR DESCRIPTION
Swap out a numpy command that no longer exists - I'm guessing it was deprecated and removed at some point when numpy was upgraded.

This was preventing a new build of TRTools from being published. I'm not sure our automated testing pipeline is running any more - is should've caught this.

Also added a few command line tests for associaTR