### PR TITLE
fix: vcf input via stdin

### DIFF
--- a/trtools/utils/tests/test_utils.py
+++ b/trtools/utils/tests/test_utils.py
@@ -1,4 +1,4 @@
-import io, os, sys
+import os, sys
 import numpy as np
 import pytest
 
@@ -12,11 +12,6 @@ def test_LoadSingleReader(monkeypatch, vcfdir):
     assert file2 is not None
     file3 = utils.LoadSingleReader(os.path.join(vcfdir, "nonexistent.vcf"), checkgz=False)
     assert file3 is None
-    # # TODO: figure out how to test stdin
-    # with open(os.path.join(vcfdir, "test_gangstr.vcf"), "r") as file4:
-    #     os.fdopen(0, 'w').write(file4.read())
-    #     file4 = utils.LoadSingleReader("/dev/stdin", checkgz=False)
-    # assert file4 is not None
 
 # ValidateAlleleFreqs
 def test_ValidateAlleleFreqs():

--- a/trtools/utils/tests/test_utils.py
+++ b/trtools/utils/tests/test_utils.py
@@ -1,8 +1,22 @@
-import os, sys
+import io, os, sys
 import numpy as np
 import pytest
 
 import trtools.utils.utils as utils
+
+# LoadSingleReader
+def test_LoadSingleReader(monkeypatch, vcfdir):
+    file1 = utils.LoadSingleReader(os.path.join(vcfdir, "few_samples_few_loci.vcf.gz"))
+    assert file1 is not None
+    file2 = utils.LoadSingleReader(os.path.join(vcfdir, "test_gangstr.vcf"), checkgz=False)
+    assert file2 is not None
+    file3 = utils.LoadSingleReader(os.path.join(vcfdir, "nonexistent.vcf"), checkgz=False)
+    assert file3 is None
+    # # TODO: figure out how to test stdin
+    # with open(os.path.join(vcfdir, "test_gangstr.vcf"), "r") as file4:
+    #     os.fdopen(0, 'w').write(file4.read())
+    #     file4 = utils.LoadSingleReader("/dev/stdin", checkgz=False)
+    # assert file4 is not None
 
 # ValidateAlleleFreqs
 def test_ValidateAlleleFreqs():

--- a/trtools/utils/utils.py
+++ b/trtools/utils/utils.py
@@ -35,7 +35,8 @@ def LoadSingleReader(
     reader : Optional[cyvcf2.VCF]
         The cyvcf2.VCF instance, or None if the VCF is not present
     """
-    if not os.path.isfile(vcf_loc):
+    # check that vcf_loc is a file or file descriptor (ex: '/dev/stdin')
+    if not os.path.exists(vcf_loc) or os.path.isdir(vcf_loc):
         common.WARNING("Could not find VCF file %s"%vcf_loc)
         return None
     if checkgz:


### PR DESCRIPTION
allows `trtools` to accept piped VCFs or VCFs that are specified via process substitution

Previously, the user would simply receive this error message, instead:
> Could not find VCF file